### PR TITLE
Show API failure message when the API fails

### DIFF
--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -79,6 +79,8 @@ class TripsController < ApplicationController
       }
     directions = GoogleDirections.new(start_address, end_address, cycle_options)
 
+    fail directions.status if directions.distance == 0
+
     drive_time_in_minutes = directions.drive_time_in_minutes
     distance_in_m = directions.distance.to_i
     xml = directions.xml


### PR DESCRIPTION
When the distance lookup fails, this will show the error message so you know why the API hasn't given you any info.