### PR TITLE
Investigate crash from search

### DIFF
--- a/app/controllers/pitstops_controller.rb
+++ b/app/controllers/pitstops_controller.rb
@@ -41,7 +41,7 @@ end
 
 def find_places(lat, lng)
   client = GooglePlaces::Client.new(ENV['GOOGLE_API_BROWSER_KEY'])
-  spots = client.spots(lat, lng, types: 'lodging')
+  spots = client.spots(lat, lng, types: "lodging")
 
   spot_array = []
   spots.each do |spot|

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -43,7 +43,7 @@ private
 
 def find_places(lat, lng)
   client = GooglePlaces::Client.new(ENV['GOOGLE_API_BROWSER_KEY'])
-  spots = client.spots(lat, lng, :types => 'lodging')
+  spots = client.spots(lat, lng, :types => "lodging")
 
   spot_array = []
   spots.each do |spot|

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -97,10 +97,10 @@ class TripsController < ApplicationController
     routes = gmaps.directions(
       start_address,
       end_address,
-      mode: 'bicycling',
+      mode: "bicycling",
       alternatives: false,
-      avoid: 'highways',
-      avoid: 'ferries'
+      avoid: "highways",
+      avoid: "ferries"
       )
 
 

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -3,17 +3,17 @@ class Stage < ApplicationRecord
   has_one :start_point, class_name: "Pitstop", foreign_key: "start_stage_id", dependent: :destroy
   has_one :end_point, class_name: "Pitstop", foreign_key: "end_stage_id", dependent: :destroy
 
-default_scope { order('stage_no ASC') }
+default_scope { order("stage_no ASC") }
 
   def compute_distance
     return nil unless start_point && end_point
 
     gmaps = GoogleMapsService::Client.new(key: ENV['GOOGLE_API_BROWSER_KEY'])
-    routes = gmaps.directions(start_point.address, end_point.address,
-    mode: 'bicycling',
+    routes = gmaps.directions((origin=start_point.latitude,start_point.longitude), (destination=end_point.latitude,end_point.longitude),
+    mode: "bicycling",
     alternatives: false,
-    avoid: 'highways',
-    avoid: 'ferries'
+    avoid: "highways",
+    avoid: "ferries"
     )
 
     distance_in_m = routes[0][:legs][0][:distance][:value]

--- a/app/models/stage.rb
+++ b/app/models/stage.rb
@@ -7,7 +7,7 @@ default_scope { order("stage_no ASC") }
 
   def compute_distance
     return nil unless start_point && end_point
-
+# start_point.address changed to lat/lng to allow unnamed roads
     gmaps = GoogleMapsService::Client.new(key: ENV['GOOGLE_API_BROWSER_KEY'])
     routes = gmaps.directions((origin=start_point.latitude,start_point.longitude), (destination=end_point.latitude,end_point.longitude),
     mode: "bicycling",

--- a/app/views/pitstops/edit.html.erb
+++ b/app/views/pitstops/edit.html.erb
@@ -14,13 +14,13 @@
 
 <% hotel_no = 1 %>
 <% @hotels.each do |hotel| %>
-<div id="clickChangeAddress" onclick="update_address('<%= hotel[:vicinity] %>');" style="cursor: pointer;">
+<div id="clickChangeAddress" onclick="update_address("<%= hotel[:vicinity] %>");" style="cursor: pointer;">
 
   <h4><%= hotel_no %>: <%= hotel[:name] %></h4>
   <% hotel_no += 1 %>
   <p><%= hotel[:vicinity] %></p>
   <p>Rating: <%= hotel[:rating] %></p>
-  
+
 </div>
 
 <% end %>
@@ -39,7 +39,7 @@
 
   <script>
    function changeValue(o){
-     document.getElementById('address').value=o.innerHTML;
+     document.getElementById("address").value=o.innerHTML;
    }
  </script>
 

--- a/app/views/trips/show.html.erb
+++ b/app/views/trips/show.html.erb
@@ -167,11 +167,15 @@
 
   function calcRoute() {
     /* This code iterates over each stage of a user trip and sets the waypoint(s) as the end_point address as defined by the user */
+    /*end_stage.address changed to lat.long and parseFloat so when the address is an unanamed road it will show on the map.  */
 
     var waypts = [];
     <% @trip.stages.each do |stage|  %>
+    var userLat = parseFloat("<%= raw stage.end_point.latitude %>")
+    var userLng = parseFloat("<%= raw stage.end_point.longitude %>")
+    var endPointAsCoodinates = { lat: userLat, lng:userLng};
     <% break if stage.end_point.final_stop? %>
-    var stop = '<%= raw stage.end_point.address %>'
+    var stop = endPointAsCoodinates;
     waypts.push({
       location: stop,
       stopover: true,


### PR DESCRIPTION
This stops the error with unnamed roads by using coordinates instead of address.